### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ Detailed performance and introduction are shown in this <a href="https://qwenlm.
 </table>
 
 ## Requirements
+* `python>=3.9`
 * `transformers>=4.37.0` for Qwen1.5 dense models.
 
 > [!Warning]


### PR DESCRIPTION
restrict python version `python>=3.9`

when using python=3.8 ,some unexpected bugs occurs. 
```
>>> from transformers import AutoTokenizer
>>> checkpoint = "/cpfs01/shared/public/chuzhe.hby/CodeQwen-public/CodeQwen-7B"
>>> tokenizer = AutoTokenizer.from_pretrained(checkpoint)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/conda/envs/py38/lib/python3.8/site-packages/transformers/models/auto/tokenization_auto.py", line 862, in from_pretrained
    return tokenizer_class.from_pretrained(pretrained_model_name_or_path, *inputs, **kwargs)
  File "/opt/conda/envs/py38/lib/python3.8/site-packages/transformers/tokenization_utils_base.py", line 2089, in from_pretrained
    return cls._from_pretrained(
  File "/opt/conda/envs/py38/lib/python3.8/site-packages/transformers/tokenization_utils_base.py", line 2311, in _from_pretrained
    tokenizer = cls(*init_inputs, **init_kwargs)
  File "/opt/conda/envs/py38/lib/python3.8/site-packages/transformers/tokenization_utils_fast.py", line 111, in __init__
    fast_tokenizer = TokenizerFast.from_file(fast_tokenizer_file)
Exception: data did not match any variant of untagged enum PyPreTokenizerTypeWrapper at line 12564 column 3 
```