### PR TITLE
remove redundant import

### DIFF
--- a/evaluation/multipl_e/base/humaneval.py
+++ b/evaluation/multipl_e/base/humaneval.py
@@ -9,7 +9,6 @@ import torch
 import datetime
 import subprocess
 import torch.distributed as dist
-from attrdict import AttrDict
 from human_eval.evaluation import evaluate_functional_correctness
 from transformers import AutoTokenizer
 from utils.dataset import HumanEvalDataset


### PR DESCRIPTION
This is a redundant import. attrdict was not maintained since 2019. Additionally I found its import `Mapping` from `collections` is not consistent with python 3.10.