### PR TITLE
fix(sft): supported transformers for qwen3_moe

### DIFF
--- a/finetuning/sft/requirements.txt
+++ b/finetuning/sft/requirements.txt
@@ -83,7 +83,7 @@ tensorboardX==2.6.2.2
 termcolor==2.4.0
 tokenizers==0.21.0
 tqdm==4.66.5
-transformers==4.47.1
+transformers==4.51.0
 triton==3.0.0
 trl==0.9.6
 typeguard==4.4.1


### PR DESCRIPTION
We were getting this error during the SFT
https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct#quickstart