### PR TITLE
Fix: Qwen3CoderHandler import in BFCL model_config

### DIFF
--- a/qwencoder-eval/tool_calling_eval/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
+++ b/qwencoder-eval/tool_calling_eval/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
@@ -29,6 +29,7 @@ from bfcl_eval.model_handler.api_inference.qwen import (
     QwenAgentThinkHandler,
     QwenAPIHandler,
 )
+from bfcl_eval.model_handler.api_inference.qwen3_coder import Qwen3CoderHandler
 from bfcl_eval.model_handler.api_inference.writer import WriterHandler
 from bfcl_eval.model_handler.api_inference.yi import YiHandler
 from bfcl_eval.model_handler.local_inference.arch import ArchHandler

--- a/qwencoder-eval/tool_calling_eval/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/qwen3_coder.py
+++ b/qwencoder-eval/tool_calling_eval/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/qwen3_coder.py
@@ -2,7 +2,9 @@ import json
 import os
 import time
 
-from bfcl_eval.model_handler.api_inference.openai import OpenAIHandler
+from bfcl_eval.model_handler.api_inference.openai_completion import (
+    OpenAICompletionsHandler as OpenAIHandler,
+)
 from bfcl_eval.model_handler.model_style import ModelStyle
 from bfcl_eval.model_handler.utils import retry_with_backoff
 from openai import OpenAI, RateLimitError
@@ -21,7 +23,7 @@ error_list = [
 class Qwen3CoderHandler(OpenAIHandler):
     def __init__(self, model_name, temperature) -> None:
         super().__init__(model_name, temperature)
-        self.model_style = ModelStyle.OpenAI
+        self.model_style = ModelStyle.OpenAI_Completions
         self.model_name = model_name
         base_url, api_key = os.getenv("OPENAI_API_BASE"), os.getenv("OPENAI_API_KEY")
         litellm.api_base = base_url


### PR DESCRIPTION
- Running `bfcl generate --model Qwen3-Coder-480B-A35B-Instruct --num-threads 8` fails with:
```
Traceback (most recent call last):
  File "/root/.local/bin/bfcl", line 5, in <module>
    from bfcl_eval.__main__ import cli
  File "/root/work/filestorage/cyy/Qwen3-Coder/Qwen3-Coder-main/qwencoder-eval/tool_calling_eval/berkeley-function-call-leaderboard/bfcl_eval/__main__.py", line 9, in <module>
    from bfcl_eval._llm_response_generation import main as generation_main
  File "/root/work/filestorage/cyy/Qwen3-Coder/Qwen3-Coder-main/qwencoder-eval/tool_calling_eval/berkeley-function-call-leaderboard/bfcl_eval/_llm_response_generation.py", line 19, in <module>
    from bfcl_eval.eval_checker.eval_runner_helper import load_file
  File "/root/work/filestorage/cyy/Qwen3-Coder/Qwen3-Coder-main/qwencoder-eval/tool_calling_eval/berkeley-function-call-leaderboard/bfcl_eval/eval_checker/eval_runner_helper.py", line 11, in <module>
    from bfcl_eval.constants.model_config import MODEL_CONFIG_MAPPING
  File "/root/work/filestorage/cyy/Qwen3-Coder/Qwen3-Coder-main/qwencoder-eval/tool_calling_eval/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py", line 1678, in <module>
    model_handler=Qwen3CoderHandler,
                  ^^^^^^^^^^^^^^^^^
NameError: name 'Qwen3CoderHandler' is not defined. Did you mean: 'QwenFCHandler'?
```