### PR TITLE
Fix assistant-first message crash by adding safe message parsing

### DIFF
--- a/demo/chatbot/app.py
+++ b/demo/chatbot/app.py
@@ -36,14 +36,41 @@ def history_to_messages(history: History, system: str) -> Messages:
         messages.append({'role': Role.ASSISTANT, 'content': h[1]})
     return messages
 
-
 def messages_to_history(messages: Messages) -> Tuple[str, History]:
-    assert messages[0]['role'] == Role.SYSTEM
-    system = messages[0]['content']
+    """
+    Safely convert messages into system prompt and chat history.
+
+    Fixes:
+    - Prevent crash if system message is missing
+    - Handles assistant-first edge cases
+    - Avoids fragile zip pairing
+    """
+
+    # Ensure system message exists
+    if not messages or messages[0]['role'] != Role.SYSTEM:
+        system = default_system
+        messages = [{'role': Role.SYSTEM, 'content': system}] + (messages or [])
+    else:
+        system = messages[0]['content']
+
     history = []
-    for q, r in zip(messages[1::2], messages[2::2]):
-        history.append([q['content'], r['content']])
+    user_msg = None
+
+    # Safely reconstruct conversation
+    for msg in messages[1:]:
+        role = msg.get("role")
+        content = msg.get("content", "")
+
+        if role == Role.USER:
+            user_msg = content
+
+        elif role == Role.ASSISTANT:
+            if user_msg is not None:
+                history.append([user_msg, content])
+                user_msg = None
+
     return system, history
+
 
 
 def model_chat(query: Optional[str], history: Optional[History], system: str,


### PR DESCRIPTION
Fixes #550

## Problem
The application assumes that the first message is always a system message and
uses strict assertions along with zip-based pairing when reconstructing chat history.

If the message order becomes inconsistent (for example assistant appearing first
due to streaming, session restore, or malformed history), the app can crash with:

"Invalid input, the first message must not be an assistant message."

## Solution
- Removed the strict assertion on message order
- Implemented defensive parsing to safely reconstruct chat history
- Ensured a system message is always present
- Replaced fragile zip pairing with sequential role validation

## Result
This prevents crashes caused by malformed message history and improves
overall robustness of the chat application without changing expected behavior.
