### PR TITLE
Add MiniMax M3 to BFCL model registry

### DIFF
--- a/qwencoder-eval/tool_calling_eval/berkeley-function-call-leaderboard/bfcl_eval/.env.example
+++ b/qwencoder-eval/tool_calling_eval/berkeley-function-call-leaderboard/bfcl_eval/.env.example
@@ -7,6 +7,8 @@ NVIDIA_API_KEY=nvapi-XXXXXX
 DEEPSEEK_API_KEY=sk-XXXXXX
 # We use Alibaba Cloud (aliyun.com) to inference Qwen models
 QWEN_API_KEY=sk-XXXXXX
+MINIMAX_API_KEY=
+MINIMAX_BASE_URL=https://api.minimax.io/v1
 YI_API_KEY=
 COHERE_API_KEY=
 GROK_API_KEY=xai-XXXXXX

--- a/qwencoder-eval/tool_calling_eval/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
+++ b/qwencoder-eval/tool_calling_eval/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
@@ -14,6 +14,7 @@ from bfcl_eval.model_handler.api_inference.gorilla import GorillaHandler
 from bfcl_eval.model_handler.api_inference.grok import GrokHandler
 from bfcl_eval.model_handler.api_inference.ling import LingAPIHandler
 from bfcl_eval.model_handler.api_inference.mining import MiningHandler
+from bfcl_eval.model_handler.api_inference.minimax import MiniMaxHandler
 from bfcl_eval.model_handler.api_inference.mistral import MistralHandler
 from bfcl_eval.model_handler.api_inference.nemotron import NemotronHandler
 from bfcl_eval.model_handler.api_inference.nexus import NexusHandler
@@ -162,6 +163,30 @@ api_inference_model_map = {
         model_handler=DeepSeekAPIHandler,
         input_price=None,
         output_price=None,
+        is_fc_model=True,
+        underscore_to_dot=True,
+    ),
+    "MiniMax-M3": ModelConfig(
+        model_name="MiniMax-M3",
+        display_name="MiniMax-M3 (Prompt)",
+        url="https://platform.minimax.io/docs/api-reference/api-overview",
+        org="MiniMax",
+        license="Proprietary",
+        model_handler=MiniMaxHandler,
+        input_price=0.6,
+        output_price=2.4,
+        is_fc_model=False,
+        underscore_to_dot=False,
+    ),
+    "MiniMax-M3-FC": ModelConfig(
+        model_name="MiniMax-M3-FC",
+        display_name="MiniMax-M3 (FC)",
+        url="https://platform.minimax.io/docs/api-reference/api-overview",
+        org="MiniMax",
+        license="Proprietary",
+        model_handler=MiniMaxHandler,
+        input_price=0.6,
+        output_price=2.4,
         is_fc_model=True,
         underscore_to_dot=True,
     ),

--- a/qwencoder-eval/tool_calling_eval/berkeley-function-call-leaderboard/bfcl_eval/constants/supported_models.py
+++ b/qwencoder-eval/tool_calling_eval/berkeley-function-call-leaderboard/bfcl_eval/constants/supported_models.py
@@ -17,6 +17,8 @@ SUPPORTED_MODELS = [
     "DeepSeek-R1-0528",
     "DeepSeek-R1-0528-FC",
     "DeepSeek-V3-0324-FC",
+    "MiniMax-M3",
+    "MiniMax-M3-FC",
     "gpt-4.5-preview-2025-02-27",
     "gpt-4.5-preview-2025-02-27-FC",
     "gpt-4.1-2025-04-14-FC",

--- a/qwencoder-eval/tool_calling_eval/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/minimax.py
+++ b/qwencoder-eval/tool_calling_eval/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/minimax.py
@@ -1,0 +1,15 @@
+import os
+
+from bfcl_eval.model_handler.api_inference.openai_completion import OpenAICompletionsHandler
+from bfcl_eval.model_handler.model_style import ModelStyle
+from openai import OpenAI
+
+
+class MiniMaxHandler(OpenAICompletionsHandler):
+    def __init__(self, model_name, temperature) -> None:
+        super().__init__(model_name, temperature)
+        self.model_style = ModelStyle.OpenAI_Completions
+        self.client = OpenAI(
+            base_url=os.getenv("MINIMAX_BASE_URL", "https://api.minimax.io/v1"),
+            api_key=os.getenv("MINIMAX_API_KEY"),
+        )


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry

## Summary
- Add MiniMax-M3 prompt and function-calling entries to the BFCL model registry.
- Add a MiniMax OpenAI-compatible handler using the documented base URL and MINIMAX_API_KEY.
- Document MiniMax environment variables in the BFCL example env file.

## Test plan
- python3 -m py_compile qwencoder-eval/tool_calling_eval/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/minimax.py qwencoder-eval/tool_calling_eval/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py qwencoder-eval/tool_calling_eval/berkeley-function-call-leaderboard/bfcl_eval/constants/supported_models.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)